### PR TITLE
Feat/api proxy handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import { sitesHandler } from './lib/sitesHandler'
 import { createAuthorizationHandler } from './lib/authorizationHandler'
+import { createApiProxyHandler } from './lib/apiProxyHandler'
 import {
   basicAuthenticationHandler,
   createKVCredentialsVerifier
@@ -9,5 +10,6 @@ export {
   sitesHandler,
   basicAuthenticationHandler,
   createKVCredentialsVerifier,
-  createAuthorizationHandler
+  createAuthorizationHandler,
+  createApiProxyHandler
 }

--- a/lib/apiProxyHandler/index.js
+++ b/lib/apiProxyHandler/index.js
@@ -1,0 +1,45 @@
+/* global DOWNSTREAM_HOST */
+
+import { RequestCookieStore } from '@worker-tools/request-cookie-store'
+
+export const createApiProxyHandler = DOWNSTREAM_HOST => {
+  return async (request, event, config) => {
+    const {
+      body,
+      headers,
+      method,
+      redirect,
+      url
+    } = request
+
+    try {
+      const proxyURL = new URL(url)
+      const downstreamUrl = new URL(DOWNSTREAM_HOST)
+      proxyURL.pathname = proxyURL.pathname.replace(/^\/api/, '')
+      proxyURL.host = downstreamUrl.host
+      proxyURL.port = downstreamUrl.port
+      proxyURL.protocol = downstreamUrl.protocol
+
+      const proxyHeaders = new Headers(headers)
+
+      const cookieStore = new RequestCookieStore(request)
+      // Cookie must be decrypted here
+      const { value: decryptedToken } = await cookieStore.get('token')
+      // Cookie must be decrypted here
+
+      proxyHeaders.delete('cookie')
+      proxyHeaders.append('Bearer', decryptedToken)
+
+      const modifiedRequest = new Request(proxyURL.toString(), {
+        body,
+        headers: proxyHeaders,
+        method,
+        redirect
+      })
+
+      return fetch(modifiedRequest)
+    } catch (err) {
+      throw new Error('Error proxying to the API', { cause: err })
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.1.3",
+    "@worker-tools/request-cookie-store": "^0.4.2",
     "itty-router": "^2.4.4",
     "itty-router-extras": "^0.4.2",
     "oso": "^0.22.0"


### PR DESCRIPTION
## Summary

Moved API proxy handler into request handlers repo in preparation for use in Fasdentify

## Test Plan

- Should be tested in conjunction with autotelic/skipper-otto-dock#491
- checkout both the dock repo and branch, and this one
- `npm i` & `npm link` in this repo
- yarn the dock from root then `npm link @autotelic/worker-request-handlers` in the `workers-site` directory
- follow the test plan from autotelic/skipper-otto-dock#456, confirm everything still works