### PR TITLE
feat: token extraction

### DIFF
--- a/lib/apiProxyHandler/index.js
+++ b/lib/apiProxyHandler/index.js
@@ -1,8 +1,4 @@
-/* global DOWNSTREAM_HOST */
-
-import { RequestCookieStore } from '@worker-tools/request-cookie-store'
-
-export const createApiProxyHandler = DOWNSTREAM_HOST => {
+export const createApiProxyHandler = ({ DOWNSTREAM_HOST, extractToken }) => {
   return async (request, event, config) => {
     const {
       body,
@@ -11,6 +7,10 @@ export const createApiProxyHandler = DOWNSTREAM_HOST => {
       redirect,
       url
     } = request
+
+    if (typeof extractToken !== 'function') {
+      throw new Error('Must provide a token extraction function: extractToken.')
+    }
 
     try {
       const proxyURL = new URL(url)
@@ -22,12 +22,7 @@ export const createApiProxyHandler = DOWNSTREAM_HOST => {
 
       const proxyHeaders = new Headers(headers)
 
-      const cookieStore = new RequestCookieStore(request)
-      // Cookie must be decrypted here
-      const { value: decryptedToken } = await cookieStore.get('token')
-      // Cookie must be decrypted here
-
-      proxyHeaders.delete('cookie')
+      const decryptedToken = extractToken(request)
       proxyHeaders.append('Bearer', decryptedToken)
 
       const modifiedRequest = new Request(proxyURL.toString(), {

--- a/lib/createCookieEncryptor.js
+++ b/lib/createCookieEncryptor.js
@@ -8,7 +8,7 @@ const toHexString = bytes =>
 const fromHexString = hexString =>
   new Uint8Array(hexString.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
 
-export const createCookieEncryptor = ({ cookieName, encryptionKey, keyAlgorithm }) => {
+export const createCookieEncryptor = ({ cookieName, encryptionKey, keyAlgorithm = 'AES-GCM' }) => {
   const getKey = async () => {
     try {
       return crypto.subtle.importKey(
@@ -51,6 +51,11 @@ export const createCookieEncryptor = ({ cookieName, encryptionKey, keyAlgorithm 
     }
   }
 
+  const extractToken = (request) => {
+    const { cookies } = request
+    return cookies ? cookies[cookieName] : null
+  }
+
   const decryptionHandler = async (request, event, config) => {
     try {
       const cookieStore = new RequestCookieStore(request)
@@ -66,13 +71,14 @@ export const createCookieEncryptor = ({ cookieName, encryptionKey, keyAlgorithm 
       cookieObj[cookieName] = decrypted
       request.cookies = cookieObj
     } catch (e) {
-      throw new StatusError(400, e.message)
+      throw new StatusError(400, e.message || e.toString())
     }
   }
 
   return {
     encrypt,
     decrypt,
+    extractToken,
     decryptionHandler
   }
 }


### PR DESCRIPTION
## Summary
The apiProxyHandler will need to extract the decrypted token from the request.cookies object and set it as a Bearer token in the proxy headers. Since the `createCookieEncryptor` already has access to the cookieName, a method exported from here: `extractToken` will find and return the decrypted token. This can then be passed to the `createApiProxyHandler` function.

## Test Plan
- for test implementation, see this PR: https://github.com/autotelic/skipper-otto-dock/pull/416