### PR TITLE
feat: missing cookie handler

### DIFF
--- a/lib/createCookieEncryptor.js
+++ b/lib/createCookieEncryptor.js
@@ -8,7 +8,16 @@ const toHexString = bytes =>
 const fromHexString = hexString =>
   new Uint8Array(hexString.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
 
-export const createCookieEncryptor = ({ cookieName, encryptionKey, keyAlgorithm = 'AES-GCM' }) => {
+export const createCookieEncryptor = (opts) => {
+  const {
+    cookieName,
+    encryptionKey,
+    keyAlgorithm = 'AES-GCM',
+    missingCookieHandler = async () => {
+      throw new StatusError(400, 'Missing required cookie.')
+    }
+  } = opts
+
   const getKey = async () => {
     try {
       return crypto.subtle.importKey(
@@ -65,7 +74,7 @@ export const createCookieEncryptor = ({ cookieName, encryptionKey, keyAlgorithm 
         return obj
       }, {})
       if (!cookieObj.hasOwnProperty(cookieName)) {
-        throw new StatusError(400, 'Missing required cookie.')
+        return missingCookieHandler(request, event)
       }
       const decrypted = await decrypt(cookieObj[cookieName])
       cookieObj[cookieName] = decrypted


### PR DESCRIPTION
## Summary
The decryptionHandler has a configurable function when a cookie is missing. The default missingCookieHandler will still throw an error, but we can now configure different behaviour if necessary.

## Test Plan
Use https://github.com/autotelic/skipper-otto-dock/pull/585 to test
