### PR TITLE
feat: configurable response & error handlers for sitesHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { createSitesHandler } from './lib/sitesHandler'
+import { createSitesHandler, createSitesErrorHandler } from './lib/sitesHandler'
 import { createAuthorizationHandler } from './lib/authorizationHandler'
 import { createApiProxyHandler } from './lib/apiProxyHandler'
 import { createCookieEncryptor } from './lib/createCookieEncryptor'
@@ -9,6 +9,7 @@ import {
 
 export {
   createSitesHandler,
+  createSitesErrorHandler,
   basicAuthenticationHandler,
   createKVCredentialsVerifier,
   createAuthorizationHandler,

--- a/lib/authorizationHandler/index.js
+++ b/lib/authorizationHandler/index.js
@@ -13,7 +13,6 @@ const defaultConfig = {
 export const createAuthorizationHandler = (config = defaultConfig) => {
   return async (request, event) => {
     const {
-      getAuthorizationCookie,
       getUser,
       getRequest,
       setupOso,
@@ -23,26 +22,21 @@ export const createAuthorizationHandler = (config = defaultConfig) => {
       ...defaultConfig,
       ...config
     }
-    const isAlreadyAuthorized = await getAuthorizationCookie(request)
-    if (!isAlreadyAuthorized) {
-      const [oso, user, req] = await Promise.all([
-        await getOso(setupOso),
-        await getUser(request, event),
-        await getRequest(request, event)
-      ])
-      try {
-        await oso.authorizeRequest(user, req)
-        request.authorized = true
-      } catch (e) {
-        if (throwErrors) {
-          throw new StatusError(403, authorizationErrorMessage)
-        } else {
-          request.authorized = false
-          request.authorizationError = e.message
-        }
-      }
-    } else {
+    const [oso, user, req] = await Promise.all([
+      await getOso(setupOso),
+      await getUser(request, event),
+      await getRequest(request, event)
+    ])
+    try {
+      await oso.authorizeRequest(user, req)
       request.authorized = true
+    } catch (e) {
+      if (throwErrors) {
+        throw new StatusError(403, authorizationErrorMessage)
+      } else {
+        request.authorized = false
+        request.authorizationError = e.message
+      }
     }
   }
 }

--- a/lib/authorizationHandler/index.js
+++ b/lib/authorizationHandler/index.js
@@ -2,6 +2,7 @@ import { StatusError } from 'itty-router-extras'
 import getOso from './getOso.js'
 
 const defaultConfig = {
+  getAuthorizationCookie: async request => null,
   getUser: async () => {},
   getRequest: async request => request,
   setupOso: async oso => {},
@@ -12,6 +13,7 @@ const defaultConfig = {
 export const createAuthorizationHandler = (config = defaultConfig) => {
   return async (request, event) => {
     const {
+      getAuthorizationCookie,
       getUser,
       getRequest,
       setupOso,
@@ -21,21 +23,26 @@ export const createAuthorizationHandler = (config = defaultConfig) => {
       ...defaultConfig,
       ...config
     }
-    const [oso, user, req] = await Promise.all([
-      await getOso(setupOso),
-      await getUser(request, event),
-      await getRequest(request, event)
-    ])
-    try {
-      await oso.authorizeRequest(user, req)
-      request.authorized = true
-    } catch (e) {
-      if (throwErrors) {
-        throw new StatusError(403, authorizationErrorMessage)
-      } else {
-        request.authorized = false
-        request.authorizationError = e.message
+    const isAlreadyAuthorized = await getAuthorizationCookie(request)
+    if (!isAlreadyAuthorized) {
+      const [oso, user, req] = await Promise.all([
+        await getOso(setupOso),
+        await getUser(request, event),
+        await getRequest(request, event)
+      ])
+      try {
+        await oso.authorizeRequest(user, req)
+        request.authorized = true
+      } catch (e) {
+        if (throwErrors) {
+          throw new StatusError(403, authorizationErrorMessage)
+        } else {
+          request.authorized = false
+          request.authorizationError = e.message
+        }
       }
+    } else {
+      request.authorized = true
     }
   }
 }

--- a/lib/authorizationHandler/index.test.js
+++ b/lib/authorizationHandler/index.test.js
@@ -27,6 +27,24 @@ test('request allowed', async ({ notThrowsAsync, context, assert }) => {
   assert(request.authorized)
 })
 
+test('already authorized', async t => {
+  const getUser = sinon.spy()
+  const getRequest = sinon.spy()
+  const setupOso = sinon.spy()
+  const authorizationHandler = createAuthorizationHandler({
+    getAuthorizationCookie: request => true,
+    getUser,
+    getRequest,
+    setupOso
+  })
+  let request = {}
+  await t.notThrowsAsync(authorizationHandler(request))
+  t.true(getUser.notCalled)
+  t.true(getRequest.notCalled)
+  t.true(setupOso.notCalled)
+  t.true(request.authorized)
+})
+
 test('request not allowed, throw errors', async ({ throwsAsync, context }) => {
   const { config } = context
   const authorizationHandler = createAuthorizationHandler(config)

--- a/lib/sitesHandler.js
+++ b/lib/sitesHandler.js
@@ -1,8 +1,30 @@
-const { getAssetFromKV } = require('@cloudflare/kv-asset-handler')
+import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
+import { StatusError } from 'itty-router-extras'
 
 const defaultConfig = {
   debug: false,
   responseHandler: async (request, assetResponse) => assetResponse
+}
+
+const workersSitesErrorHandler = async (e, event) => {
+  try {
+    const { status } = e
+    console.log(status, e.message)
+    const filePath = status == 404
+      ? `${status}.html`
+      : `${status}/index.html`
+    const errorResponse = await getAssetFromKV(event, {
+      mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/${filePath}`, req)
+    })
+    return new Response(errorResponse.body, { ...errorResponse, status })
+  } catch (e) {
+    console.log('it is throwing here', e)
+    throw e
+  }
+}
+
+export const createSitesErrorHandler = event => {
+  return async e => await workersSitesErrorHandler(e, event)
 }
 
 export const createSitesHandler = (config = defaultConfig) => {
@@ -32,14 +54,10 @@ export const createSitesHandler = (config = defaultConfig) => {
       const { body: assetBody } = finalResponse
       return new Response(assetBody, finalResponse)
     } catch (e) {
-      // if an error is thrown try to serve the asset at 404.html
-      if (!DEBUG) {
-        try {
-          const notFoundResponse = await getAssetFromKV(event, {
-            mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/404.html`, req)
-          })
-          return new Response(notFoundResponse.body, { ...notFoundResponse, status: 404 })
-        } catch (e) {}
+      console.log(e, typeof e)
+      // if a not found error is thrown try to serve the asset at 404.html
+      if (e.message.startsWith('could not find') && e.message.endsWith('in your content namespace')) {
+        return await workersSitesErrorHandler(new StatusError(404, e.message), event)
       }
       return new Response(e.message || e.toString(), { status: 500 })
     }

--- a/lib/sitesHandler.js
+++ b/lib/sitesHandler.js
@@ -1,12 +1,21 @@
 const { getAssetFromKV } = require('@cloudflare/kv-asset-handler')
 
-export const createSitesHandler = () => {
-  return async (request, event, config = {
-    debug: true
-  }) => {
+const defaultConfig = {
+  debug: false,
+  responseHandler: async (request, assetResponse) => assetResponse
+}
+
+export const createSitesHandler = (config = defaultConfig) => {
+  return async (request, event) => {
     const url = new URL(request.url)
     const options = {}
-    const { debug: DEBUG } = config
+    const {
+      debug: DEBUG,
+      responseHandler
+    } = {
+      ...defaultConfig,
+      ...config
+    }
 
     try {
       // bypass cache if we are developing
@@ -15,7 +24,13 @@ export const createSitesHandler = () => {
           bypassCache: true
         }
       }
-      return await getAssetFromKV(event, options)
+      const assetResponse = await getAssetFromKV(event, options)
+      const finalResponse = await responseHandler(request, assetResponse, {
+        ...defaultConfig,
+        ...config
+      })
+      const { body: assetBody } = finalResponse
+      return new Response(assetBody, finalResponse)
     } catch (e) {
       // if an error is thrown try to serve the asset at 404.html
       if (!DEBUG) {

--- a/lib/sitesHandler.js
+++ b/lib/sitesHandler.js
@@ -6,6 +6,21 @@ const defaultConfig = {
   responseHandler: async (request, assetResponse) => assetResponse
 }
 
+const workersSitesErrorHandler = async (e, event) => {
+  try {
+    const { status } = e
+    const filePath = status == 404
+      ? `${status}.html`
+      : `${status}/index.html`
+    const errorResponse = await getAssetFromKV(event, {
+      mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/${filePath}`, req)
+    })
+    return new Response(errorResponse.body, { ...errorResponse, status })
+  } catch (e) {
+    throw e
+  }
+}
+
 export const createSitesHandler = (config = defaultConfig) => {
   return async (request, event) => {
     const url = new URL(request.url)

--- a/lib/sitesHandler.js
+++ b/lib/sitesHandler.js
@@ -6,27 +6,6 @@ const defaultConfig = {
   responseHandler: async (request, assetResponse) => assetResponse
 }
 
-const workersSitesErrorHandler = async (e, event) => {
-  try {
-    const { status } = e
-    console.log(status, e.message)
-    const filePath = status == 404
-      ? `${status}.html`
-      : `${status}/index.html`
-    const errorResponse = await getAssetFromKV(event, {
-      mapRequestToAsset: req => new Request(`${new URL(req.url).origin}/${filePath}`, req)
-    })
-    return new Response(errorResponse.body, { ...errorResponse, status })
-  } catch (e) {
-    console.log('it is throwing here', e)
-    throw e
-  }
-}
-
-export const createSitesErrorHandler = event => {
-  return async e => await workersSitesErrorHandler(e, event)
-}
-
 export const createSitesHandler = (config = defaultConfig) => {
   return async (request, event) => {
     const url = new URL(request.url)
@@ -54,7 +33,6 @@ export const createSitesHandler = (config = defaultConfig) => {
       const { body: assetBody } = finalResponse
       return new Response(assetBody, finalResponse)
     } catch (e) {
-      console.log(e, typeof e)
       // if a not found error is thrown try to serve the asset at 404.html
       if (e.message.startsWith('could not find') && e.message.endsWith('in your content namespace')) {
         return await workersSitesErrorHandler(new StatusError(404, e.message), event)


### PR DESCRIPTION
## Summary

- switched `sitesHandler` to factory method & object config
- added configurable response handler & KV error handler

## Test Plan

I originally refactored this in order to set a cookie on the response from within the sites handler. Ended up not needing it but I am 100% certain having a configurable response handler method will be useful in the future. Same with the error handler.

To test, confirm that the sites handler still works as expected on autotelic/skipper-otto-dock#599