### PR TITLE
Spike/more testing attempts

### DIFF
--- a/lib/apiProxyHandler/index.js
+++ b/lib/apiProxyHandler/index.js
@@ -23,8 +23,15 @@ export const createApiProxyHandler = ({ DOWNSTREAM_HOST, extractToken }) => {
       const proxyHeaders = new Headers(headers)
 
       const decryptedToken = extractToken(request)
-      proxyHeaders.append('Bearer', decryptedToken)
 
+      // remove existing authorization headers
+      // TODO(eadmundo): maybe this should be a configurable authHeaderHandler method
+      proxyHeaders.delete('Authorization')
+
+      // replace with our token header if we have one
+      if (decryptedToken) {
+        proxyHeaders.append('Authorization', `Bearer: ${decryptedToken}`)
+      }
       const modifiedRequest = new Request(proxyURL.toString(), {
         body,
         headers: proxyHeaders,

--- a/lib/authorizationHandler/index.test.js
+++ b/lib/authorizationHandler/index.test.js
@@ -27,24 +27,6 @@ test('request allowed', async ({ notThrowsAsync, context, assert }) => {
   assert(request.authorized)
 })
 
-test('already authorized', async t => {
-  const getUser = sinon.spy()
-  const getRequest = sinon.spy()
-  const setupOso = sinon.spy()
-  const authorizationHandler = createAuthorizationHandler({
-    getAuthorizationCookie: request => true,
-    getUser,
-    getRequest,
-    setupOso
-  })
-  let request = {}
-  await t.notThrowsAsync(authorizationHandler(request))
-  t.true(getUser.notCalled)
-  t.true(getRequest.notCalled)
-  t.true(setupOso.notCalled)
-  t.true(request.authorized)
-})
-
 test('request not allowed, throw errors', async ({ throwsAsync, context }) => {
   const { config } = context
   const authorizationHandler = createAuthorizationHandler(config)

--- a/lib/cookieEncryptor/index.js
+++ b/lib/cookieEncryptor/index.js
@@ -1,0 +1,96 @@
+import base64url from 'base64url'
+import { RequestCookieStore } from '@worker-tools/request-cookie-store'
+import { StatusError } from 'itty-router-extras'
+
+const toHexString = bytes =>
+  bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '')
+
+const fromHexString = hexString =>
+  new Uint8Array(hexString.match(/.{1,2}/g).map(byte => parseInt(byte, 16)))
+
+export const createCookieEncryptor = (opts) => {
+  const {
+    cookieName,
+    encryptionKey,
+    keyAlgorithm = 'AES-GCM',
+    missingCookieHandler = async () => {
+      throw new StatusError(400, 'Missing required cookie.')
+    }
+  } = opts
+
+  const getKey = async () => {
+    try {
+      return crypto.subtle.importKey(
+        'raw',
+        base64url.toBuffer(encryptionKey),
+        { name: keyAlgorithm },
+        false,
+        ['encrypt', 'decrypt']
+      )
+    } catch (e) {
+      throw new StatusError(400, e.message || e.toString())
+    }
+  }
+
+  const encrypt = async str => {
+    try {
+      const key = await getKey(keyAlgorithm)
+      const iv = crypto.getRandomValues(new Uint8Array(16))
+      const encoder = new TextEncoder()
+      const data = encoder.encode(str)
+      const encrypted = await crypto.subtle.encrypt({ name: keyAlgorithm, iv }, key, data)
+      return `${toHexString(iv)}${base64url(encrypted)}`
+    } catch (e) {
+      throw new StatusError(400, e.message || e.toString())
+    }
+  }
+
+  const decrypt = async str => {
+    try {
+      const iv = fromHexString(str.slice(0, 32))
+      const token = str.slice(32)
+      const key = await getKey(keyAlgorithm)
+      const decrypted = await crypto.subtle.decrypt({
+        name: keyAlgorithm, iv
+      }, key, base64url.toBuffer(token))
+      const decoder = new TextDecoder()
+      return decoder.decode(decrypted)
+    } catch (e) {
+      throw new StatusError(400, e.message || e.toString())
+    }
+  }
+
+  const extractToken = (request) => {
+    const { cookies } = request
+    return cookies ? cookies[cookieName] : null
+  }
+
+  const decryptionHandler = async (request, event, config) => {
+    try {
+      const cookieStore = new RequestCookieStore(request)
+      const allCookies = await cookieStore.getAll()
+      const cookieObj = allCookies.reduce((obj, { name, value }) => {
+        obj[name] = value
+        return obj
+      }, {})
+      const hasCookie = cookieObj.hasOwnProperty(cookieName)
+      if (!hasCookie) {
+        missingCookieHandler(request, event)
+      }
+      if (hasCookie) {
+        const decrypted = await decrypt(cookieObj[cookieName])
+        cookieObj[cookieName] = decrypted
+        request.cookies = cookieObj
+      }
+    } catch (e) {
+      throw new StatusError(400, e.message || e.toString())
+    }
+  }
+
+  return {
+    encrypt,
+    decrypt,
+    extractToken,
+    decryptionHandler
+  }
+}

--- a/lib/cookieEncryptor/index.test.js
+++ b/lib/cookieEncryptor/index.test.js
@@ -1,0 +1,23 @@
+import test from 'ava'
+import { Miniflare } from 'miniflare'
+import { createCookieEncryptor } from './index.js'
+
+test.beforeEach((t) => {
+  const mf = new Miniflare({
+    scriptPath: './lib/cookieEncryptor/worker.js'
+  })
+
+  // const { decrypt, encrypt, extractToken, decryptionHandler } = createCookieEncryptor({
+  //   cookieName: 'cookieName',
+  //   encryptionKey: 'm1wGHPBiT3psGFbuT6tPYbnQ5cC7HdhcgRzwit551io'
+  // })
+
+  t.context = { mf }
+})
+
+test("just give it a go", async (t) => {
+  const { mf } = t.context
+  t.pass()
+  const res = await mf.dispatchFetch("http://localhost:8787/");
+  // t.is(await res.text(), "ok");
+})

--- a/lib/cookieEncryptor/worker.js
+++ b/lib/cookieEncryptor/worker.js
@@ -1,0 +1,15 @@
+// import { ThrowableRouter } from 'itty-router-extras'
+import { createCookieEncryptor } from './index.js'
+
+const { decrypt, encrypt, extractToken, decryptionHandler } = createCookieEncryptor({
+  cookieName: 'cookieName',
+  encryptionKey: 'm1wGHPBiT3psGFbuT6tPYbnQ5cC7HdhcgRzwit551io'
+})
+//
+// const router = ThrowableRouter()
+//
+// router.all('*', request => new Response('ok'))
+
+addEventListener('fetch', event => {
+  event.respondWith(new Response('ok'))
+})

--- a/lib/createCookieEncryptor.js
+++ b/lib/createCookieEncryptor.js
@@ -73,12 +73,15 @@ export const createCookieEncryptor = (opts) => {
         obj[name] = value
         return obj
       }, {})
-      if (!cookieObj.hasOwnProperty(cookieName)) {
-        return missingCookieHandler(request, event)
+      const hasCookie = cookieObj.hasOwnProperty(cookieName)
+      if (!hasCookie) {
+        missingCookieHandler(request, event)
       }
-      const decrypted = await decrypt(cookieObj[cookieName])
-      cookieObj[cookieName] = decrypted
-      request.cookies = cookieObj
+      if (hasCookie) {
+        const decrypted = await decrypt(cookieObj[cookieName])
+        cookieObj[cookieName] = decrypted
+        request.cookies = cookieObj
+      }
     } catch (e) {
       throw new StatusError(400, e.message || e.toString())
     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "ava": "^3.15.0",
+    "miniflare": "^1.4.1",
     "sinon": "^12.0.1",
     "standard": "^16.0.4"
   }


### PR DESCRIPTION
This is another attempt to move forward for #14 - am trying to create a "harness" worker file to run the handler in miniflare. 

- if we try to import `createCookieEncryptor` in a worker scriptPath within miniflare in the test, `lib/cookieEncryptor/worker.js` throws `SyntaxError: Cannot use import statement outside a module`

- If we try to import `createCookieEncryptor` directly into a test file we get `Cannot find module '[snip path]/worker-request-handlers/node_modules/@worker-tools/request-cookie-store/set-cookie'`