### PR TITLE
feat: add dev server proxy

### DIFF
--- a/lib/sitesHandler.js
+++ b/lib/sitesHandler.js
@@ -1,10 +1,13 @@
-/* global Request, Response */
+/* global Request, Response, fetch */
 
 import { getAssetFromKV } from '@cloudflare/kv-asset-handler'
 import { StatusError } from 'itty-router-extras'
 
 const defaultConfig = {
   debug: false,
+  devServer: false,
+  devServerHandler,
+  devServerOpts: {},
   responseHandler: async (request, assetResponse) => assetResponse
 }
 
@@ -24,7 +27,10 @@ export const createSitesHandler = (config = defaultConfig) => {
     const options = {}
     const {
       debug: DEBUG,
-      responseHandler
+      responseHandler,
+      devServer,
+      devServerOpts,
+      devServerHandler
     } = {
       ...defaultConfig,
       ...config
@@ -36,6 +42,11 @@ export const createSitesHandler = (config = defaultConfig) => {
         options.cacheControl = {
           bypassCache: true
         }
+      }
+      console.log(devServer)
+      console.log(typeof devServer)
+      if (devServer) {
+        return await devServerHandler(devServerOpts, request)
       }
       const assetResponse = await getAssetFromKV(event, options)
       const finalResponse = await responseHandler(request, assetResponse, {
@@ -52,4 +63,10 @@ export const createSitesHandler = (config = defaultConfig) => {
       return new Response(e.message || e.toString(), { status: 500 })
     }
   }
+}
+
+async function devServerHandler (devServerOpts, request) {
+  const url = new URL(request.url)
+  url.port = devServerOpts.port
+  return fetch(new Request(url), request)
 }

--- a/lib/sitesHandler.js
+++ b/lib/sitesHandler.js
@@ -43,8 +43,6 @@ export const createSitesHandler = (config = defaultConfig) => {
           bypassCache: true
         }
       }
-      console.log(devServer)
-      console.log(typeof devServer)
       if (devServer) {
         return await devServerHandler(devServerOpts, request)
       }


### PR DESCRIPTION
# Summary

Developing UIs in conjunction with CF workers can be challenging. the DX of rebuilding the application and serving it from the worker is slow and not ideal. This pull request adds a devServer option to the siteHandler which will proxy requests to a local development server (e.g the webpack dev server). This allows for a CF worker to serve a UI application, and still do things like modify requests, but allow for UI to be rapidly developed (including hot module replacement)

# Test Plan

- Link this package in an existing CF worker static site project.
- Build and run the UI via the dev-server
- Update the CF site handler to include the following options:
```js
{
  devServer: true,
  devServerOpts: { port: 8001  // port is wherever the webpack dev server is running }
}
```
- make a request to the UI through the cloudflare worker
- the request should server the application
- update the UI code, the application should hot reload and update the UI.