### PR TITLE
feat: verify jwks handler

### DIFF
--- a/examples/verify-jwks/README.md
+++ b/examples/verify-jwks/README.md
@@ -1,0 +1,7 @@
+# JWKS Verification Handler Example
+
+- `npm install`
+- `npm run key-gen`
+- copy the public jwk into index.js where the comment is.
+- `npm run dev`
+- `curl -H "Authorization: Bearer <use jwt here>" http://127.0.0.1:8787`

--- a/examples/verify-jwks/getKeyAndJwt.js
+++ b/examples/verify-jwks/getKeyAndJwt.js
@@ -1,0 +1,15 @@
+import {
+  SignJWT,
+  generateKeyPair,
+  exportJWK
+} from 'jose'
+
+;(async () => {
+  const { publicKey, privateKey } = await generateKeyPair('RS256')
+  const publicJwk = await exportJWK(publicKey)
+  const jwt = await new SignJWT({ 'urn:example:claim': true })
+    .setProtectedHeader({ alg: 'RS256' })
+    .sign(privateKey)
+  console.log(`public jwk:\n\n`, publicJwk)
+  console.log(`\n\njwt:\n\n`, jwt, '\n')
+})()

--- a/examples/verify-jwks/index.js
+++ b/examples/verify-jwks/index.js
@@ -1,0 +1,30 @@
+import { ThrowableRouter } from 'itty-router-extras'
+import { createLocalJWKSet, createRemoteJWKSet } from 'jose'
+import { createVerifyJwksHandler } from '../../lib/verifyJwksHandler'
+
+const getJwks = async request => {
+  return createLocalJWKSet({
+    keys: [
+      // insert public jwk here
+    ]
+  })
+}
+
+const verifyJWKsHandler = createVerifyJwksHandler({
+  getJwks,
+  onVerified: (request, verificationResult) => {
+    console.log(verificationResult)
+  }
+})
+
+const router = ThrowableRouter()
+
+router
+  .all('*', verifyJWKsHandler, request => {
+    return new Response('hello world')
+  })
+
+addEventListener('fetch', event => {
+  const request = new Request(event.request)
+  event.respondWith(router.handle(request))
+})

--- a/examples/verify-jwks/package.json
+++ b/examples/verify-jwks/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "verify-jwks",
+  "version": "1.0.0",
+  "description": "",
+  "main": "./dist/index.js",
+  "type": "module",
+  "scripts": {
+    "build": "esbuild --bundle --sourcemap --outdir=dist ./index.js",
+    "dev": "miniflare --watch --debug",
+    "key-gen": "node ./getKeyAndJwt.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "itty-router": "^2.6.1",
+    "itty-router-extras": "^0.4.2",
+    "miniflare": "^2.4.0"
+  },
+  "devDependencies": {
+    "esbuild": "^0.14.38"
+  }
+}

--- a/examples/verify-jwks/wrangler.toml
+++ b/examples/verify-jwks/wrangler.toml
@@ -1,0 +1,11 @@
+name = "esbuild-worker"
+type = "javascript"
+account_id = ""
+workers_dev = true
+route = ""
+zone_id = ""
+
+[build]
+command = "npm run build"
+[build.upload]
+format = "service-worker"

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import {
   createBasicAuthenticationHandler,
   createKVCredentialsVerifier
 } from './lib/basicAuthenticationHandler'
+import { createVerifyJwksHandler } from './lib/verifyJwksHandler'
 
 export {
   createSitesHandler,
@@ -16,5 +17,6 @@ export {
   createAuthorizationHandler,
   createApiProxyHandler,
   createCookieEncryptor,
-  generateStateParam
+  generateStateParam,
+  createVerifyJwksHandler,
 }

--- a/lib/verifyJwksHandler/index.js
+++ b/lib/verifyJwksHandler/index.js
@@ -1,0 +1,62 @@
+import { StatusError } from 'itty-router-extras'
+import { jwtVerify, errors } from 'jose'
+
+export const getJWT = async request => {
+  const authorizationHeader = request.headers.get('Authorization')
+  if (authorizationHeader === null) {
+    return null
+  }
+
+  const [scheme, jwt] = authorizationHeader.split(' ')
+
+  if (!jwt || scheme !== 'Bearer') {
+    throw new StatusError(400, 'Malformed Authorization header.')
+  }
+
+  return jwt
+}
+
+export const onNotVerified = error => {
+  if (error instanceof errors.JOSEError) {
+    // TODO (eadmundo): differentiate between different JOSE errors for logging
+    // https://github.com/panva/jose/blob/main/docs/modules/util_errors.md#readme
+    throw new StatusError(401, 'Invalid Access Token')
+  }
+  else {
+    // this isn't expected so re-throw
+    throw error
+  }
+}
+
+const defaultConfig = {
+  getJwks: async request => null,
+  getJWT,
+  onVerified: (request, verificationResult) => {},
+  onNotVerified: () => {},
+}
+
+export const createVerifyJwksHandler = (config = defaultConfig) => {
+  const {
+    getJwks,
+    getJWT,
+    onVerified,
+    onNotVerified
+  } = {
+    ...defaultConfig,
+    ...config
+  }
+
+  return async (request, event) => {
+    const jwks = await getJwks(request)
+    const jwt = await getJWT(request)
+
+    if (jwt !== null) {
+      try {
+        const verificationResult = await jwtVerify(jwt, jwks)
+        onVerified(request, verificationResult)
+      } catch (error) {
+        onNotVerified(error)
+      }
+    }
+  }
+}

--- a/lib/verifyJwksHandler/index.test.js
+++ b/lib/verifyJwksHandler/index.test.js
@@ -1,0 +1,135 @@
+import test from 'ava'
+import sinon from 'sinon'
+import { KeyObject } from 'crypto'
+import {
+  createLocalJWKSet,
+  SignJWT,
+  errors,
+  generateKeyPair,
+  exportJWK
+} from 'jose'
+import { StatusError } from 'itty-router-extras'
+import { createVerifyJwksHandler, getJWT, onNotVerified } from './index.js'
+
+test.beforeEach(async (t) => {
+  const { publicKey, privateKey } = await generateKeyPair('RS256')
+  const publicJwk = await exportJWK(publicKey)
+
+  const config = {
+    getJwks: async request => createLocalJWKSet({
+      keys: [publicJwk]
+    })
+  }
+
+  t.context = {
+    config,
+    privateKey,
+  }
+})
+
+test('verified', async t => {
+  const { context } = t
+  const { config, privateKey } = context
+  const expectedPayload = { 'urn:example:claim': true }
+  const expectedProtectedHeader = { alg: 'RS256' }
+  const getTestJWT = async () => await new SignJWT(expectedPayload)
+    .setProtectedHeader(expectedProtectedHeader)
+    .sign(privateKey)
+  const onVerifiedSpy = sinon.spy()
+  const onNotVerifiedSpy = sinon.spy()
+  const request = { foo: 'bar' }
+  const verifyJwksHandler = createVerifyJwksHandler({
+    ...config,
+    getJWT: getTestJWT,
+    onVerified: onVerifiedSpy,
+    onNotVerified: onNotVerifiedSpy,
+  })
+
+  await t.notThrowsAsync(verifyJwksHandler(request))
+  const { payload, protectedHeader, key } = onVerifiedSpy.getCall(0).args[1]
+  t.deepEqual(onVerifiedSpy.getCall(0).args[0], { foo: 'bar' })
+  t.true(onVerifiedSpy.calledOnce)
+  t.true(onNotVerifiedSpy.notCalled)
+  t.deepEqual(payload, expectedPayload)
+  t.deepEqual(protectedHeader, expectedProtectedHeader)
+  t.true(key instanceof KeyObject)
+})
+
+test('not verified', async t => {
+  const { context: { config } } = t
+  const getTestJWT = async () => ''
+  const onVerifiedSpy = sinon.spy()
+  const onNotVerifiedSpy = sinon.spy()
+  const verifyJwksHandler = createVerifyJwksHandler({
+    ...config,
+    getJWT: getTestJWT,
+    onVerified: onVerifiedSpy,
+    onNotVerified: onNotVerifiedSpy,
+  })
+  await verifyJwksHandler({})
+  t.true(onVerifiedSpy.notCalled)
+  t.true(onNotVerifiedSpy.calledOnce)
+  t.true(onNotVerifiedSpy.getCall(0).args[0] instanceof errors.JOSEError)
+})
+
+test('default getJWT no header', async t => {
+  const requestStub = {
+    headers: {
+      get: sinon.stub().withArgs('Authorization').returns(null)
+    }
+  }
+  const jwt = await getJWT(requestStub)
+  t.is(jwt, null)
+})
+
+test('default getJWT with well-formed header', async t => {
+  const requestStub = {
+    headers: {
+      get: sinon.stub().withArgs('Authorization').returns('Bearer JWT')
+    }
+  }
+  const jwt = await getJWT(requestStub)
+  t.is(jwt, 'JWT')
+})
+
+test('default getJWT with malformed header, wrong scheme', async t => {
+  const requestStub = {
+    headers: {
+      get: sinon.stub().withArgs('Authorization').returns('Holder JWT')
+    }
+  }
+  const error = await t.throwsAsync(getJWT(requestStub), {
+    instanceOf: StatusError,
+    message: 'Malformed Authorization header.',
+  })
+  t.is(error.status, 400)
+})
+
+test('default getJWT with malformed header, no jwt', async t => {
+  const requestStub = {
+    headers: {
+      get: sinon.stub().withArgs('Authorization').returns('Bearer')
+    }
+  }
+  const error = await t.throwsAsync(getJWT(requestStub), {
+    instanceOf: StatusError,
+    message: 'Malformed Authorization header.',
+  })
+  t.is(error.status, 400)
+})
+
+test('default onNotVerified is jose error', async t => {
+  const joseError = new errors.JOSEError()
+  const error = t.throws(() => onNotVerified(joseError), {
+    instanceOf: StatusError,
+    message: 'Invalid Access Token',
+  })
+  t.is(error.status, 401)
+})
+
+test('default onNotVerified non jose error passed through', async t => {
+  const error = t.throws(() => onNotVerified(new TypeError('some issue')), {
+    instanceOf: TypeError,
+    message: 'some issue',
+  })
+})

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "fix": "npm run lint -- --fix",
     "lint": "standard",
     "test": "ava --verbose lib/**/*.test.js",
-    "validate": "npm run lint && npm run test"
+    "validate": "npm run lint && npm run test",
+    "verify": "miniflare examples/verify-jwks/index.js"
   },
   "author": "",
   "license": "MIT",
@@ -18,7 +19,8 @@
     "base64url": "^3.0.1",
     "itty-router": "^2.4.4",
     "itty-router-extras": "^0.4.2",
-    "oso": "^0.26.0"
+    "oso": "^0.26.0",
+    "jose": "^4.8.0"
   },
   "devDependencies": {
     "ava": "^4.1.0",


### PR DESCRIPTION
## Summary

- part of resolution to autotelic/skipper-otto-dock#782
- moves `verifyJWKsHandler` into this module and makes it a bit more generic

## Test Plan

- `npm install` in root dir
- follow the instructions in `/examples/verify-jwks/README.md`
- see no errors, `hello world`
- run tests