### PR TITLE
Fix/return on not verified jwks verify handler

### DIFF
--- a/lib/verifyJwksHandler/index.js
+++ b/lib/verifyJwksHandler/index.js
@@ -48,16 +48,14 @@ export const createVerifyJwksHandler = (config = defaultConfig) => {
 
   return async (request, event) => {
     const jwks = await getJwks(request)
-    console.log('jwks', jwks)
     const jwt = await getJWT(request)
-    console.log('jwt', jwt)
 
     if (jwt !== null) {
       try {
         const verificationResult = await jwtVerify(jwt, jwks)
         onVerified(request, verificationResult)
       } catch (error) {
-        await onNotVerified(request, error)
+        return await onNotVerified(request, error)
       }
     }
   }

--- a/lib/verifyJwksHandler/index.js
+++ b/lib/verifyJwksHandler/index.js
@@ -16,7 +16,7 @@ export const getJWT = async request => {
   return jwt
 }
 
-export const onNotVerified = error => {
+export const onNotVerified = async (request, error) => {
   if (error instanceof errors.JOSEError) {
     // TODO (eadmundo): differentiate between different JOSE errors for logging
     // https://github.com/panva/jose/blob/main/docs/modules/util_errors.md#readme
@@ -48,14 +48,16 @@ export const createVerifyJwksHandler = (config = defaultConfig) => {
 
   return async (request, event) => {
     const jwks = await getJwks(request)
+    console.log('jwks', jwks)
     const jwt = await getJWT(request)
+    console.log('jwt', jwt)
 
     if (jwt !== null) {
       try {
         const verificationResult = await jwtVerify(jwt, jwks)
         onVerified(request, verificationResult)
       } catch (error) {
-        onNotVerified(error)
+        await onNotVerified(request, error)
       }
     }
   }

--- a/lib/verifyJwksHandler/index.test.js
+++ b/lib/verifyJwksHandler/index.test.js
@@ -121,7 +121,7 @@ test('default getJWT with malformed header, no jwt', async t => {
 
 test('default onNotVerified is jose error', async t => {
   const joseError = new errors.JOSEError()
-  const error = t.throws(() => onNotVerified({}, joseError), {
+  const error = await t.throwsAsync(() => onNotVerified({}, joseError), {
     instanceOf: StatusError,
     message: 'Invalid Access Token',
   })
@@ -129,7 +129,7 @@ test('default onNotVerified is jose error', async t => {
 })
 
 test('default onNotVerified non jose error passed through', async t => {
-  const error = t.throws(() => onNotVerified({}, new TypeError('some issue')), {
+  const error = await t.throwsAsync(() => onNotVerified({}, new TypeError('some issue')), {
     instanceOf: TypeError,
     message: 'some issue',
   })

--- a/lib/verifyJwksHandler/index.test.js
+++ b/lib/verifyJwksHandler/index.test.js
@@ -69,7 +69,8 @@ test('not verified', async t => {
   await verifyJwksHandler({})
   t.true(onVerifiedSpy.notCalled)
   t.true(onNotVerifiedSpy.calledOnce)
-  t.true(onNotVerifiedSpy.getCall(0).args[0] instanceof errors.JOSEError)
+  t.deepEqual(onNotVerifiedSpy.getCall(0).args[0], {})
+  t.true(onNotVerifiedSpy.getCall(0).args[1] instanceof errors.JOSEError)
 })
 
 test('default getJWT no header', async t => {
@@ -120,7 +121,7 @@ test('default getJWT with malformed header, no jwt', async t => {
 
 test('default onNotVerified is jose error', async t => {
   const joseError = new errors.JOSEError()
-  const error = t.throws(() => onNotVerified(joseError), {
+  const error = t.throws(() => onNotVerified({}, joseError), {
     instanceOf: StatusError,
     message: 'Invalid Access Token',
   })
@@ -128,7 +129,7 @@ test('default onNotVerified is jose error', async t => {
 })
 
 test('default onNotVerified non jose error passed through', async t => {
-  const error = t.throws(() => onNotVerified(new TypeError('some issue')), {
+  const error = t.throws(() => onNotVerified({}, new TypeError('some issue')), {
     instanceOf: TypeError,
     message: 'some issue',
   })


### PR DESCRIPTION
## Summary

- needed to return out of the `onNotVerified` handler for autotelic/skipper-otto-dock#862 to work

## Test Plan

- run tests
- test with autotelic/skipper-otto-dock#862